### PR TITLE
[GCP] move to F2 for 512Mb memory limit

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,2 @@
 runtime: nodejs16
-resources:
-  memory_gb: 0.5
+instance_class: F2


### PR DESCRIPTION
See https://cloud.google.com/appengine/docs/standard/#instance_classes