### PR TITLE
Use HTTPS all the time for crafting the URLs

### DIFF
--- a/paf-mvp-demo-express/src/config.ts
+++ b/paf-mvp-demo-express/src/config.ts
@@ -1,5 +1,9 @@
+// Our production environment use HTTPS at the load-balancer level.
+// Therefore, in this environment, we use internally HTTP but we forge all
+// our URL in HTTPS.
+// TODO: Refine the system to me more friendly with the dev environment.
 export const isHttps = false
-export const protocol = isHttps ? 'https' : 'http'
+export const protocol = 'https'
 
 export interface Config {
     host: string;


### PR DESCRIPTION
In production www.crto-poc-2.com/assets/cmp/cmp.js
and crto-poc-2.com/assets/paf-lib.js are called in
HTTP.